### PR TITLE
SR-11-1 & SR-11-2: Schema refactor and seeder update for PopulationSupply, Livability, and HousingMarket

### DIFF
--- a/backend/SettlyDbManager/DataSeeder.cs
+++ b/backend/SettlyDbManager/DataSeeder.cs
@@ -267,10 +267,10 @@ public class DataSeeder
 
         var populationSupplyFaker = new Faker<PopulationSupply>()
             .RuleFor(ps => ps.SuburbId, f => f.PickRandom(suburbIds))
-            .RuleFor(ps => ps.Population, f => f.Random.Int(5000, 150000))
-            .RuleFor(ps => ps.PopulationGrowthRate, f => f.Random.Decimal(-0.02m, 0.08m))
+            // .RuleFor(ps => ps.Population, f => f.Random.Int(5000, 150000))
+            // .RuleFor(ps => ps.PopulationGrowthRate, f => f.Random.Decimal(-0.02m, 0.08m))
             .RuleFor(ps => ps.RentersRatio, f => f.Random.Decimal(0.2m, 0.7m))
-            .RuleFor(ps => ps.LandSupply, f => f.PickRandom(landSupplyTypes))
+            // .RuleFor(ps => ps.LandSupply, f => f.PickRandom(landSupplyTypes))
             .RuleFor(ps => ps.BuildingApprovals12M, f => f.Random.Int(50, 2000))
             .RuleFor(ps => ps.SnapshotDate, f => f.Date.Between(DateTime.UtcNow.AddMonths(-12), DateTime.UtcNow));
 
@@ -285,8 +285,8 @@ public class DataSeeder
         var livabilityFaker = new Faker<Livability>()
             .RuleFor(l => l.SuburbId, f => f.PickRandom(suburbIds))
             .RuleFor(l => l.TransportScore, f => f.Random.Decimal(1.0m, 10.0m))
-            .RuleFor(l => l.DistSupermarket, f => f.Random.Decimal(0.5m, 15.0m))
-            .RuleFor(l => l.DistHospital, f => f.Random.Decimal(2.0m, 50.0m))
+            // .RuleFor(l => l.DistSupermarket, f => f.Random.Decimal(0.5m, 15.0m))
+            // .RuleFor(l => l.DistHospital, f => f.Random.Decimal(2.0m, 50.0m))
             .RuleFor(l => l.PrimarySchoolRating, f => f.Random.Decimal(6.0m, 10.0m))
             .RuleFor(l => l.SecondarySchoolRating, f => f.Random.Decimal(6.0m, 10.0m))
             .RuleFor(l => l.HospitalDensity, f => f.Random.Decimal(0.1m, 5.0m))
@@ -303,7 +303,7 @@ public class DataSeeder
         var riskDevelopmentFaker = new Faker<RiskDevelopment>()
             .RuleFor(rd => rd.SuburbId, f => f.PickRandom(suburbIds))
             .RuleFor(rd => rd.CrimeRate, f => f.Random.Decimal(0.5m, 8.0m))
-            .RuleFor(rd => rd.DevProjectsCount, f => f.Random.Int(0, 50))
+            // .RuleFor(rd => rd.DevProjectsCount, f => f.Random.Int(0, 50))
             .RuleFor(rd => rd.SnapshotDate, f => f.Date.Between(DateTime.UtcNow.AddMonths(-12), DateTime.UtcNow));
 
         var riskDevelopments = riskDevelopmentFaker.Generate(100);

--- a/backend/SettlyDbManager/DataSeeder.cs
+++ b/backend/SettlyDbManager/DataSeeder.cs
@@ -229,6 +229,8 @@ public class DataSeeder
 
         var housingMarketFaker = new Faker<HousingMarket>()
             .RuleFor(hm => hm.SuburbId, f => f.PickRandom(suburbIds))
+            .RuleFor(ps => ps.Population, f => f.Random.Int(5000, 150000))
+            .RuleFor(ps => ps.PopulationGrowthRate, f => f.Random.Decimal(-0.02m, 0.08m))
             .RuleFor(hm => hm.RentalYield, f => f.Random.Decimal(0.02m, 0.08m))
             .RuleFor(hm => hm.MedianPrice, f => f.Random.Int(400000, 1500000))
             .RuleFor(hm => hm.PriceGrowth3Yr, f => f.Random.Decimal(-0.05m, 0.15m))
@@ -267,10 +269,9 @@ public class DataSeeder
 
         var populationSupplyFaker = new Faker<PopulationSupply>()
             .RuleFor(ps => ps.SuburbId, f => f.PickRandom(suburbIds))
-            // .RuleFor(ps => ps.Population, f => f.Random.Int(5000, 150000))
-            // .RuleFor(ps => ps.PopulationGrowthRate, f => f.Random.Decimal(-0.02m, 0.08m))
+            .RuleFor(ps => ps.DevProjectsCount, f => f.Random.Int(0, 50))
+            .RuleFor(ps => ps.DemandSupplyRatio, f => f.Random.Decimal(0.5m, 2.0m))
             .RuleFor(ps => ps.RentersRatio, f => f.Random.Decimal(0.2m, 0.7m))
-            // .RuleFor(ps => ps.LandSupply, f => f.PickRandom(landSupplyTypes))
             .RuleFor(ps => ps.BuildingApprovals12M, f => f.Random.Int(50, 2000))
             .RuleFor(ps => ps.SnapshotDate, f => f.Date.Between(DateTime.UtcNow.AddMonths(-12), DateTime.UtcNow));
 
@@ -285,8 +286,8 @@ public class DataSeeder
         var livabilityFaker = new Faker<Livability>()
             .RuleFor(l => l.SuburbId, f => f.PickRandom(suburbIds))
             .RuleFor(l => l.TransportScore, f => f.Random.Decimal(1.0m, 10.0m))
-            // .RuleFor(l => l.DistSupermarket, f => f.Random.Decimal(0.5m, 15.0m))
-            // .RuleFor(l => l.DistHospital, f => f.Random.Decimal(2.0m, 50.0m))
+            .RuleFor(l => l.SupermarketQuantity, f => f.Random.Int(2, 20))
+            .RuleFor(l => l.HospitalQuantity, f => f.Random.Int(1, 10))
             .RuleFor(l => l.PrimarySchoolRating, f => f.Random.Decimal(6.0m, 10.0m))
             .RuleFor(l => l.SecondarySchoolRating, f => f.Random.Decimal(6.0m, 10.0m))
             .RuleFor(l => l.HospitalDensity, f => f.Random.Decimal(0.1m, 5.0m))
@@ -303,7 +304,6 @@ public class DataSeeder
         var riskDevelopmentFaker = new Faker<RiskDevelopment>()
             .RuleFor(rd => rd.SuburbId, f => f.PickRandom(suburbIds))
             .RuleFor(rd => rd.CrimeRate, f => f.Random.Decimal(0.5m, 8.0m))
-            // .RuleFor(rd => rd.DevProjectsCount, f => f.Random.Int(0, 50))
             .RuleFor(rd => rd.SnapshotDate, f => f.Date.Between(DateTime.UtcNow.AddMonths(-12), DateTime.UtcNow));
 
         var riskDevelopments = riskDevelopmentFaker.Generate(100);

--- a/backend/SettlyModels/Entities/HousingMarket.cs
+++ b/backend/SettlyModels/Entities/HousingMarket.cs
@@ -13,6 +13,10 @@ public class HousingMarket
     public int MedianRent { get; set; }
     public decimal RentGrowth12M { get; set; }
     public decimal VacancyRate { get; set; }
+
+     public int Population { get; set; }
+    public decimal PopulationGrowthRate { get; set; }
+
     public DateTime SnapshotDate { get; set; }
 
     public Suburb Suburb { get; set; } = null!;

--- a/backend/SettlyModels/Entities/Livability.cs
+++ b/backend/SettlyModels/Entities/Livability.cs
@@ -5,8 +5,10 @@ public class Livability
     public int Id { get; set; }
     public int SuburbId { get; set; }
     public decimal TransportScore { get; set; }
-    public decimal DistSupermarket { get; set; }
-    public decimal DistHospital { get; set; }
+
+    public int SupermarketQuantity { get; set; }
+    public int HospitalQuantity { get; set; }
+   
     public decimal PrimarySchoolRating { get; set; }
     public decimal SecondarySchoolRating { get; set; }
     public decimal HospitalDensity { get; set; }

--- a/backend/SettlyModels/Entities/PopulationSupply.cs
+++ b/backend/SettlyModels/Entities/PopulationSupply.cs
@@ -4,12 +4,14 @@ public class PopulationSupply
 {
     public int Id { get; set; }
     public int SuburbId { get; set; }
-    public int Population { get; set; }
-    public decimal PopulationGrowthRate { get; set; }
+
     public decimal RentersRatio { get; set; }
-    public string LandSupply { get; set; } = null!;
+    public decimal DemandSupplyRatio { get; set; }
+
     public int BuildingApprovals12M { get; set; }
     public DateTime SnapshotDate { get; set; }
+
+    public int DevProjectsCount { get; set; }
 
     public Suburb Suburb { get; set; } = null!;
 }

--- a/backend/SettlyModels/Entities/RiskDevelopment.cs
+++ b/backend/SettlyModels/Entities/RiskDevelopment.cs
@@ -5,7 +5,7 @@ public class RiskDevelopment
     public int Id { get; set; }
     public int SuburbId { get; set; }
     public decimal CrimeRate { get; set; }
-    public int DevProjectsCount { get; set; }
+    
     public DateTime SnapshotDate { get; set; }
 
     public Suburb Suburb { get; set; } = null!;


### PR DESCRIPTION
 Summary

This PR addresses both `SR-11-1` and `SR-11-2`, which involve updating the suburb-related data schema and aligning the seeders with the updated field definitions from the latest ER diagram.

---

### SR-11-1: Schema Refactor

#### 'PopulationSupply'
- Renamed 'Population' to 'DevProjectsCount'
- Renamed 'PopulationGrowthRate' to 'DemandSupplyRatio'
- Removed 'LandSupply'

#### 'HousingMarket'
- Added: 'Population', 'PopulationGrowthRate'

#### 'Livability'
- Removed: 'DistHospital' ,'DistSupermarket'
- Added: 'HospitalQuantity', 'SupermarketQuantity'

#### 'RiskDevelopment'
- Removed deprecated field: 'DevProjectsCount'

---

###  SR-11-2: Seeder Refactor

- 'PopulationSupply': Updated Faker to reflect renamed fields and removed deprecated ones.
- 'Livability': Replaced distance-based fields with quantity-based fields.
- All seeders tested using 'SettlyDbManager' via '--reset-seed'.

---

### Testing & Result

- Migration generated via EF Core 8
- Database schema updated successfully using:
  'dotnet ef database update --startup-project ../SettlyApi'


---

### Note

Although this PR focuses on 'SR-11-1' and 'SR-11-2', it also confirms that the base work for `SR-11` and `SR-12` has already been implemented during the initial backend setup. 

Therefore, this PR formally addresses and completes all related tickets: 'SR-11', 'SR-11-1', 'SR-11-2', and 'SR-12'.

All database structures and seeders are now aligned with the latest ER diagram and development standards.


Closes #62, closes #63, closes #45 closes #46