### PR TITLE
Add SetllyApiTests project to backend.sln

### DIFF
--- a/backend/backend.sln
+++ b/backend/backend.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SettlyService", "SettlyServ
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SettlyDbManager", "SettlyDbManager\SettlyDbManager.csproj", "{03FA2DA9-4FF8-4043-ABBE-5DDA7E9FEDA6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SettlyApiTests", "SettlyApiTests\SettlyApiTests.csproj", "{2F3569DE-5832-4E39-BF1D-C91C9D2D0AE2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{03FA2DA9-4FF8-4043-ABBE-5DDA7E9FEDA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{03FA2DA9-4FF8-4043-ABBE-5DDA7E9FEDA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{03FA2DA9-4FF8-4043-ABBE-5DDA7E9FEDA6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F3569DE-5832-4E39-BF1D-C91C9D2D0AE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F3569DE-5832-4E39-BF1D-C91C9D2D0AE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F3569DE-5832-4E39-BF1D-C91C9D2D0AE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F3569DE-5832-4E39-BF1D-C91C9D2D0AE2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Description:
Currently, the SetllyApiTests project is not included in the backend.sln solution file.
Because of this, Rider does not index the test project and the Unit Tests window cannot detect or run these tests directly from the IDE.

Acceptance Criteria:
	•	SetllyApiTests is added to backend.sln
	•	Rider can index the test project without showing “No Index”
	•	All tests in SetllyApiTests are visible and runnable in Rider’s Unit Tests window
	•	dotnet test command still works as expected after adding the project to the solution