### PR TITLE
Jasper/PRP-003-1-BE-Inspection-Plan-Modify-Property-Entity-and-Generate-Test-Data-for-InspectionTimeOptions

### DIFF
--- a/backend/SettlyDbManager/DataSeeder.cs
+++ b/backend/SettlyDbManager/DataSeeder.cs
@@ -221,7 +221,17 @@ public class DataSeeder
             .RuleFor(p => p.Summary, (f, p) => $"Discover this stunning {p.Bedrooms}-bedroom {p.PropertyType.ToLower()} located in a vibrant suburb. " +
                 $"Featuring {p.Features}, this property offers comfort and convenience for modern living. " +
                 $"Built in {p.YearBuilt}, it boasts {p.Bathrooms} bathrooms and {p.CarSpaces} car spaces.")
-            .RuleFor(p => p.ImageUrl, f => f.PickRandom(iamges));
+            .RuleFor(p => p.ImageUrl, f => f.PickRandom(iamges))
+            .RuleFor(p => p.InspectionTimeOptions, f =>
+            {
+                var count = f.Random.Int(0, 5);
+                var options = new List<DateTime>();
+                for (int i = 0; i < count; i++)
+                {
+                    options.Add(f.Date.Between(DateTime.UtcNow.AddDays(1), DateTime.UtcNow.AddDays(30)));
+                }
+                return options;
+            });
         var properties = propertyFaker.Generate(500);
         await _context.Properties.AddRangeAsync(properties);
     }

--- a/backend/SettlyModels/Entities/Property.cs
+++ b/backend/SettlyModels/Entities/Property.cs
@@ -16,6 +16,7 @@ public class Property
     public string[] Features { get; set; } = [];
     public string Summary { get; set; } = string.Empty;
     public string ImageUrl { get; set; } = string.Empty;
+    public List<DateTime> InspectionTimeOptions { get; set; } = new List<DateTime>();
 
     public Suburb Suburb { get; set; } = null!;
     public ICollection<Favourite> Favourites { get; set; } = new List<Favourite>();

--- a/backend/SettlyModels/Migrations/20250904232750_AddInspectionTimeOptionsToProperty.Designer.cs
+++ b/backend/SettlyModels/Migrations/20250904232750_AddInspectionTimeOptionsToProperty.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SettlyModels;
@@ -11,9 +12,11 @@ using SettlyModels;
 namespace SettlyModels.Migrations
 {
     [DbContext(typeof(SettlyDbContext))]
-    partial class SettlyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250904232750_AddInspectionTimeOptionsToProperty")]
+    partial class AddInspectionTimeOptionsToProperty
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/SettlyModels/Migrations/20250904232750_AddInspectionTimeOptionsToProperty.cs
+++ b/backend/SettlyModels/Migrations/20250904232750_AddInspectionTimeOptionsToProperty.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SettlyModels.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInspectionTimeOptionsToProperty : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "InspectionTimeOptions",
+                table: "Properties",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InspectionTimeOptions",
+                table: "Properties");
+        }
+    }
+}

--- a/backend/SettlyModels/SettlyDbContext.cs
+++ b/backend/SettlyModels/SettlyDbContext.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using SettlyModels.Entities;
+using System.Text.Json;
 
 namespace SettlyModels;
 
@@ -43,5 +44,12 @@ public class SettlyDbContext : DbContext
         modelBuilder.Entity<Property>()
             .Property(p => p.Features)
             .HasColumnType("text[]");
+
+        modelBuilder.Entity<Property>()
+            .Property(p => p.InspectionTimeOptions)
+            .HasConversion(
+                v => JsonSerializer.Serialize(v, new JsonSerializerOptions()),
+                v => JsonSerializer.Deserialize<List<DateTime>>(v, new JsonSerializerOptions()) ?? new List<DateTime>()
+            );
     }
 }


### PR DESCRIPTION
**Summary**

This PR implements the backend changes for the Inspection Plan feature by modifying the Property entity to include InspectionTimeOptions and seeding test data to support inspection scheduling functionality.

**Completed Features**

- Added InspectionTimeOptions property (List<DateTime>) to the Property entity.
- Created EF migration AddInspectionTimeOptionsToProperty and updated the database schema.
- Configured InspectionTimeOptions with JSON conversion for database storage.
- Seeded sample inspection times for properties in DataSeeder.cs to enable testing of inspection scheduling.

**File Changes**

- backend/SettlyModels/Entities/Property.cs — Added InspectionTimeOptions property.
- backend/SettlyModels/Migrations/20250904232750_AddInspectionTimeOptionsToProperty.cs — Added migration.
- backend/SettlyModels/Migrations/SettlyDbContextModelSnapshot.cs — Updated model snapshot for the new property.
- backend/SettlyModels/SettlyDbContext.cs — Configured JSON conversion for InspectionTimeOptions.
- backend/SettlyDbManager/DataSeeder.cs — Seeded sample inspection time data for properties.

**Test Result**
<img width="1115" height="577" alt="Screenshot 2025-09-05 at 9 53 42 am" src="https://github.com/user-attachments/assets/dd583131-c9f9-4f42-824f-20474d1c6e09" />

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/SettlyAI-Group/SettlyAI/242)
<!-- GitContextEnd -->