### PR TITLE
SR-9-3 Be:SaveButton - derive userId from JWT (remove userId query param)

### DIFF
--- a/backend/SettlyApi/Controllers/FavouriteController.cs
+++ b/backend/SettlyApi/Controllers/FavouriteController.cs
@@ -3,7 +3,6 @@ using SettlyModels.Dtos;
 using ISettlyService;
 using Swashbuckle.AspNetCore.Annotations;
 using Microsoft.AspNetCore.Authorization;
-using System.Security.Claims;
 using SettlyApi.Filters;
 
 namespace SettlyApi.Controllers
@@ -11,7 +10,7 @@ namespace SettlyApi.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize]
-    //validate the userId from the JWT toker
+    //validate the userId extracted from the JWT toker
     [UserIdFilter]
     public class FavouriteController : ControllerBase
     {
@@ -21,13 +20,13 @@ namespace SettlyApi.Controllers
         {
             _favouriteService = favouriteService;
         }
+        private int UserId => (int)HttpContext.Items[UserIdItemKeys.UserId]!;
         [HttpGet]
         [SwaggerOperation(Summary = "Get user favourites")]
         [SwaggerResponse(200, "Successfully retrieved favourites")]
         public async Task<IActionResult> GetFavourites()
         {
-            var userId = (int)HttpContext.Items["UserId"]!;
-            var favourites = await _favouriteService.GetFavourites(userId);
+            var favourites = await _favouriteService.GetFavourites(UserId);
             return Ok(favourites);
         }
         [HttpPost("toggle")]
@@ -35,8 +34,7 @@ namespace SettlyApi.Controllers
         [SwaggerResponse(200, "Favourite toggled")]
         public async Task<IActionResult> ToggleFavourite([FromBody] AddFavouriteDto dto)
         {
-            var userId = (int)HttpContext.Items["UserId"]!;
-            var isSaved = await _favouriteService.ToggleFavouriteAsync(dto, userId);
+            var isSaved = await _favouriteService.ToggleFavouriteAsync(dto, UserId);
             return Ok(new
             {
                 isSaved,
@@ -48,8 +46,7 @@ namespace SettlyApi.Controllers
         [SwaggerResponse(200, "Successfully retrieved favourite")]
         public async Task<IActionResult> GetSingleFavourite([FromQuery] string targetType, [FromQuery] int targetId)
         {
-            var userId = (int)HttpContext.Items["UserId"]!;
-            var favourite = await _favouriteService.GetSingleFavouriteAsync(targetType, targetId, userId);
+            var favourite = await _favouriteService.GetSingleFavouriteAsync(targetType, targetId, UserId);
             if (favourite == null)
                 return Ok(new { isSaved = false });
             return Ok(new

--- a/backend/SettlyApi/Controllers/FavouriteController.cs
+++ b/backend/SettlyApi/Controllers/FavouriteController.cs
@@ -10,7 +10,7 @@ namespace SettlyApi.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize]
-    //validate the userId extracted from the JWT toker
+    //Validate the userId extracted from the JWT token.
     [UserIdFilter]
     public class FavouriteController : ControllerBase
     {
@@ -20,7 +20,16 @@ namespace SettlyApi.Controllers
         {
             _favouriteService = favouriteService;
         }
-        private int UserId => (int)HttpContext.Items[UserIdItemKeys.UserId]!;
+        private int UserId
+        {
+            get
+            {
+                if (HttpContext.Items.TryGetValue(UserIdItemKeys.UserId, out var v)&& v is int id)
+                {
+                    return id;
+                }
+                throw new UnauthorizedAccessException("UserId missing or invalid.");            }
+        }
         [HttpGet]
         [SwaggerOperation(Summary = "Get user favourites")]
         [SwaggerResponse(200, "Successfully retrieved favourites")]

--- a/backend/SettlyApi/Controllers/FavouriteController.cs
+++ b/backend/SettlyApi/Controllers/FavouriteController.cs
@@ -4,11 +4,15 @@ using ISettlyService;
 using Swashbuckle.AspNetCore.Annotations;
 using Microsoft.AspNetCore.Authorization;
 using System.Security.Claims;
+using SettlyApi.Filters;
 
 namespace SettlyApi.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
+    //validate the userId from the JWT toker
+    [UserIdFilter]
     public class FavouriteController : ControllerBase
     {
         private readonly IFavouriteService _favouriteService;
@@ -18,30 +22,20 @@ namespace SettlyApi.Controllers
             _favouriteService = favouriteService;
         }
         [HttpGet]
-        [Authorize]
         [SwaggerOperation(Summary = "Get user favourites")]
         [SwaggerResponse(200, "Successfully retrieved favourites")]
         public async Task<IActionResult> GetFavourites()
         {
-            var userIdClaim = HttpContext.User.FindFirst(ClaimTypes.NameIdentifier);
-            if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out int userId))
-            {
-                return Unauthorized("User ID not found in token.");
-            }
+            var userId = (int)HttpContext.Items["UserId"]!;
             var favourites = await _favouriteService.GetFavourites(userId);
             return Ok(favourites);
         }
         [HttpPost("toggle")]
-        [Authorize]
         [SwaggerOperation(Summary = "Toggle a favourite item for the user")]
         [SwaggerResponse(200, "Favourite toggled")]
         public async Task<IActionResult> ToggleFavourite([FromBody] AddFavouriteDto dto)
         {
-            var userIdClaim = HttpContext.User.FindFirst(ClaimTypes.NameIdentifier);
-            if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out int userId))
-            {
-                return Unauthorized("User ID not found in token.");
-            }
+            var userId = (int)HttpContext.Items["UserId"]!;
             var isSaved = await _favouriteService.ToggleFavouriteAsync(dto, userId);
             return Ok(new
             {
@@ -50,16 +44,11 @@ namespace SettlyApi.Controllers
             });
         }
         [HttpGet("single")]
-        [Authorize]
         [SwaggerOperation(Summary = "Get single favourite by target type and ID")]
         [SwaggerResponse(200, "Successfully retrieved favourite")]
         public async Task<IActionResult> GetSingleFavourite([FromQuery] string targetType, [FromQuery] int targetId)
         {
-            var userIdClaim = HttpContext.User.FindFirst(ClaimTypes.NameIdentifier);
-            if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out int userId))
-            {
-                return Unauthorized("User ID not found in token.");
-            }
+            var userId = (int)HttpContext.Items["UserId"]!;
             var favourite = await _favouriteService.GetSingleFavouriteAsync(targetType, targetId, userId);
             if (favourite == null)
                 return Ok(new { isSaved = false });

--- a/backend/SettlyApi/Filters/UserIdFilterAttribute.cs
+++ b/backend/SettlyApi/Filters/UserIdFilterAttribute.cs
@@ -1,0 +1,26 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace SettlyApi.Filters
+{
+    public class UserIdFilterAttribute: ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (context.HttpContext.User.Identity == null || !context.HttpContext.User.Identity.IsAuthenticated)
+            {
+                context.Result = new UnauthorizedResult();
+                return;
+            }
+            var userIdClaim = context.HttpContext.User.FindFirst(ClaimTypes.NameIdentifier);
+            if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out int userId))
+            {
+                context.Result = new UnauthorizedResult();
+                return;
+            }
+            context.HttpContext.Items["UserId"] = userId;
+            base.OnActionExecuting(context);
+        }
+    }
+}

--- a/backend/SettlyApi/Filters/UserIdFilterAttribute.cs
+++ b/backend/SettlyApi/Filters/UserIdFilterAttribute.cs
@@ -19,7 +19,7 @@ namespace SettlyApi.Filters
                 context.Result = new UnauthorizedResult();
                 return;
             }
-            context.HttpContext.Items["UserId"] = userId;
+            context.HttpContext.Items[UserIdItemKeys.UserId] = userId;
             base.OnActionExecuting(context);
         }
     }

--- a/backend/SettlyApi/Filters/UserIdItemKeys.cs
+++ b/backend/SettlyApi/Filters/UserIdItemKeys.cs
@@ -1,0 +1,8 @@
+namespace SettlyApi.Filters
+{
+    public static class UserIdItemKeys
+    {
+        //key for storing the user's ID in HttpContext.Items
+        public const string UserId = "UserId";
+    }
+}

--- a/backend/SettlyApi/Filters/UserIdItemKeys.cs
+++ b/backend/SettlyApi/Filters/UserIdItemKeys.cs
@@ -2,7 +2,7 @@ namespace SettlyApi.Filters
 {
     public static class UserIdItemKeys
     {
-        //key for storing the user's ID in HttpContext.Items
-        public const string UserId = "UserId";
+        //Key for storing the user's ID in HttpContext.Items
+        public static readonly object UserId = new object();
     }
 }

--- a/backend/SettlyApi/Program.cs
+++ b/backend/SettlyApi/Program.cs
@@ -2,6 +2,7 @@ using ISettlyService;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using SettlyApi.Configuration;
+using SettlyApi.Filters;
 using SettlyApi.Middlewares;
 using SettlyModels;
 using SettlyService;
@@ -59,7 +60,6 @@ public class Program
         builder.Services.Configure<JWTConfig>(builder.Configuration.GetSection(JWTConfig.Section));
         var jwtConfig = builder.Configuration.GetSection(JWTConfig.Section).Get<JWTConfig>();
         builder.Services.AddJWT(jwtConfig);
-
         // Add a Login rate-limiter policy: 5 requests per 15 minutes per client IP
         builder.Services.AddLoginLimitRater(attempts: 5, miniutes: 15);
 

--- a/backend/SettlyApi/Program.cs
+++ b/backend/SettlyApi/Program.cs
@@ -60,6 +60,8 @@ public class Program
         builder.Services.Configure<JWTConfig>(builder.Configuration.GetSection(JWTConfig.Section));
         var jwtConfig = builder.Configuration.GetSection(JWTConfig.Section).Get<JWTConfig>();
         builder.Services.AddJWT(jwtConfig);
+        // Register the custom filter with the DI container.
+        builder.Services.AddScoped<UserIdFilterAttribute>();
         // Add a Login rate-limiter policy: 5 requests per 15 minutes per client IP
         builder.Services.AddLoginLimitRater(attempts: 5, miniutes: 15);
 


### PR DESCRIPTION
Summary
This PR updates the Favourite API to read userId from the JWT instead of requiring a userId query parameter.
Previously, POST /api/favourite/toggle accepted 'userId'. This allowed callers to spoof another user and forced the frontend to pass userId. We now extract the authenticated user from the access token via ClaimTypes.NameIdentifier, which is already present in issued JWTs. This change makes the endpoint safer and easier to consume (no more userId plumbed through clients).

What changed
Controller: FavouriteController now derives userId from JWT in all endpoints

Done:

-  Controller uses ClaimTypes.NameIdentifier across endpoints
-  Removed userId query dependency
-  200/401 response shapes stable and documented
-  Swagger Authorize path verified (Bearer prefix)
-  Manual tests on http://localhost:5100

<img width="980" height="676" alt="Capture2" src="https://github.com/user-attachments/assets/51307c93-dcdd-462f-9ef0-e53d4bcfeba8" />
<img width="322" height="382" alt="ConsoleTest" src="https://github.com/user-attachments/assets/ecb895c8-6a47-4871-9dd9-aafbc7fea116" />
<img width="1020" height="742" alt="Getsingle" src="https://github.com/user-attachments/assets/9c31f5df-8f4a-4e66-8c5e-12bf1717cc88" />

<img width="974" height="960" alt="Capture" src="https://github.com/user-attachments/assets/2b427b4c-68e7-4d17-9f12-df6c4611ea17" />

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/SettlyAI-Group/SettlyAI/248)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Favourites endpoints now require sign-in and operate for the authenticated user; toggles return explicit "added/removed" responses and single-item checks report saved status with details and timestamps.

- Refactor
  - Controller endpoints no longer accept userId parameters; user identity is derived from the authenticated session via a centralized filter.

- Bug Fixes
  - Requests without valid authentication now return 401 Unauthorized, blocking unauthenticated access to favourites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->