### PR TITLE
fix piecewise total interest&cost issues, added switch to generate yearly schedule

### DIFF
--- a/backend/SettlyFinance/Calculators/Orchestrators/PiecewiseAmortizer.cs
+++ b/backend/SettlyFinance/Calculators/Orchestrators/PiecewiseAmortizer.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using SettlyFinance.Interfaces;
 using SettlyFinance.Models;
+using SettlyFinance.Enums;
 using SettlyFinance.Utils;
 
 namespace SettlyFinance.Calculators.Orchestrators
@@ -13,77 +12,173 @@ namespace SettlyFinance.Calculators.Orchestrators
     /// Orchestrates mixed IO/PNI segments. Each segment starts with the
     /// previous segment's ending balance as its principal (loan amount).
     /// </summary>
-    public sealed class PiecewiseAmortizer :IPiecewiseAmortizer
+    public sealed class PiecewiseAmortizer : IPiecewiseAmortizer
     {
         private readonly IAmortizationEngineFactory _factory;
+
         public PiecewiseAmortizer(IAmortizationEngineFactory factory)
             => _factory = factory ?? throw new ArgumentNullException(nameof(factory));
-        public PiecewiseResult Calculate (PiecewiseInput input)
+
+        public PiecewiseResult Calculate(PiecewiseInput input)
         {
-            if (input.InitialLoanAmount <= 0m) throw new ArgumentOutOfRangeException(nameof(input.InitialLoanAmount), "Initial loan must be positive.");
+            if (input.InitialLoanAmount <= 0m)
+                throw new ArgumentOutOfRangeException(nameof(input.InitialLoanAmount), "Initial loan must be positive.");
             if (input.Segments is null || input.Segments.Count == 0)
                 throw new ArgumentException("At least one segment is required.", nameof(input.Segments));
-            var generateSchedule = input.GenerateSchedule;
-            var schedule = generateSchedule ? new List<PiecewiseScheduleRow>() : null;
+
+            // 总期数（所有段期数相加）与“剩余总摊销期数”
+            int totalPeriods = checked(input.Segments.Sum(s => s.TermPeriods));
+            int remainingTotalPeriods = totalPeriods;
+
+            bool generateSchedule = input.GenerateSchedule;
+
+            // 逐期 schedule（按你原有 PiecewiseScheduleRow 结构）
+            List<PiecewiseScheduleRow>? periodRows = generateSchedule ? new(totalPeriods) : null;
+
             decimal currentPrincipal = input.InitialLoanAmount;
             decimal totalInterest = 0m;
             decimal totalPrincipal = 0m;
             int globalPeriod = 0;
-            decimal firstSegmentPayment = 0m;
+
+            decimal firstSegmentPayment = 0m; // 一定取“第一个【段】”的期供（首段为 IO 就是 IO 的期供）
+
             for (int i = 0; i < input.Segments.Count; i++)
             {
                 var seg = input.Segments[i];
-                var segInput = new AmortizationInput(
-                   LoanAmount: currentPrincipal,
-                   AnnualInterestRate: seg.AnnualInterestRate,
-                   TermPeriods: seg.TermPeriods,
-                   Frequency: seg.Frequency,
-                   GenerateSchedule: generateSchedule && seg.GenerateSchedule,
-                   RepaymentType: seg.RepaymentType
-               );
-                var engine = _factory.GetEngine(seg.RepaymentType);
-                var segResult = engine.Calculate(segInput);
-                if (i == 0)
+                int segPeriods = seg.TermPeriods;
+                if (segPeriods <= 0)
+                    throw new ArgumentOutOfRangeException(nameof(seg.TermPeriods), "Segment term periods must be positive.");
+
+                if (seg.RepaymentType == RepaymentType.PrincipalAndInterest)
                 {
-                    firstSegmentPayment = segResult.Payment;
-                }
-                totalInterest += segResult.TotalInterest;
-                totalPrincipal += segResult.TotalPrincipal;
-                
-                if (generateSchedule && segResult.Schedule is not null)
-                {
-                    for (int k = 0; k < segResult.Schedule.Count; k++)
+                    // ★ 修复点：PNI 段的期供按“剩余总摊销期数”计算，但只推进本段 segPeriods 期
+                    var pniInput = new AmortizationInput(
+                        LoanAmount: currentPrincipal,
+                        AnnualInterestRate: seg.AnnualInterestRate,
+                        TermPeriods: remainingTotalPeriods,
+                        Frequency: seg.Frequency,
+                        RepaymentType: RepaymentType.PrincipalAndInterest,
+                        GenerateSchedule: true // 生成完整表，稍后只截取本段长度
+                    );
+
+                    var pniEngine = _factory.GetEngine(RepaymentType.PrincipalAndInterest);
+                    var full = pniEngine.Calculate(pniInput);
+
+                    // 首段的期供：如果首段就是 PNI，这里记录；若首段是 IO，会在 IO 分支记录
+                    if (i == 0)
+                        firstSegmentPayment = full.Payment;
+
+                    if (full.Schedule is null || full.Schedule.Count < segPeriods)
+                        throw new InvalidOperationException("PNI engine did not return enough schedule rows.");
+
+                    decimal segInterest = 0m;
+                    decimal segPrincipalPaid = 0m;
+
+                    if (generateSchedule)
                     {
-                        var row = segResult.Schedule[k];
-                        schedule!.Add(new PiecewiseScheduleRow(
-                            GlobalPeriod: ++globalPeriod,
-                            SegmentIndex: i,
-                            SegmentPeriod: k + 1,
-                            Payment: row.Payment,
-                            Interest: row.Interest,
-                            Principal: row.Principal,
-                            EndingBalance: row.EndingBalance,
-                            SegmentLabel: seg.Label));
-            }
-    }
+                        for (int k = 0; k < segPeriods; k++)
+                        {
+                            var row = full.Schedule[k];
+                            segInterest += row.Interest;
+                            segPrincipalPaid += row.Principal;
+                            currentPrincipal = row.EndingBalance;
+
+                            periodRows!.Add(new PiecewiseScheduleRow(
+                                GlobalPeriod: ++globalPeriod,
+                                SegmentIndex: i,
+                                SegmentPeriod: k + 1,
+                                Payment: row.Payment,
+                                Interest: row.Interest,
+                                Principal: row.Principal,
+                                EndingBalance: row.EndingBalance,
+                                SegmentLabel: seg.Label
+                            ));
+                        }
+                    }
+                    else
+                    {
+                        // 不生成逐期明细，也要推进余额与累计总期数/利息/本金
+                        for (int k = 0; k < segPeriods; k++)
+                        {
+                            var row = full.Schedule[k];
+                            segInterest += row.Interest;
+                            segPrincipalPaid += row.Principal;
+                            currentPrincipal = row.EndingBalance;
+                        }
+                        globalPeriod += segPeriods; // 关键：不开表也要累计
+                    }
+
+                    totalInterest += segInterest;
+                    totalPrincipal += segPrincipalPaid;
+                    remainingTotalPeriods -= segPeriods;
+                }
+                else if (seg.RepaymentType == RepaymentType.InterestOnly)
+                {
+                    // IO 段按“段长”计算
+                    var ioInput = new AmortizationInput(
+                        LoanAmount: currentPrincipal,
+                        AnnualInterestRate: seg.AnnualInterestRate,
+                        TermPeriods: segPeriods,
+                        Frequency: seg.Frequency,
+                        RepaymentType: RepaymentType.InterestOnly,
+                        GenerateSchedule: generateSchedule
+                    );
+
+                    var ioEngine = _factory.GetEngine(RepaymentType.InterestOnly);
+                    var io = ioEngine.Calculate(ioInput);
+
+                    // 首段是 IO，则 firstSegmentPayment 就取 IO 的期供（每期利息）
+                    if (i == 0)
+                        firstSegmentPayment = io.Payment;
+
+                    totalInterest += io.TotalInterest;
+                    totalPrincipal += io.TotalPrincipal; // 通常 0
+                    currentPrincipal = io.EndingBalance;
+
+                    if (generateSchedule && io.Schedule is not null)
+                    {
+                        for (int k = 0; k < io.Schedule.Count; k++)
+                        {
+                            var row = io.Schedule[k];
+                            periodRows!.Add(new PiecewiseScheduleRow(
+                                GlobalPeriod: ++globalPeriod,
+                                SegmentIndex: i,
+                                SegmentPeriod: k + 1,
+                                Payment: row.Payment,
+                                Interest: row.Interest,
+                                Principal: row.Principal,
+                                EndingBalance: row.EndingBalance,
+                                SegmentLabel: seg.Label
+                            ));
+                        }
+                    }
+                    else
+                    {
+                        globalPeriod += segPeriods; // 不开表也累计
+                    }
+
+                    remainingTotalPeriods -= segPeriods;
+                }
                 else
                 {
-                    globalPeriod += seg.TermPeriods;
+                    throw new NotSupportedException($"Unsupported repayment type: {seg.RepaymentType}");
                 }
-                
-                currentPrincipal = segResult.EndingBalance;
             }
+
             var totalCost = Math.Round(totalPrincipal + totalInterest, 2);
-            var result = new PiecewiseResult(
+
+            // ✅ 还原为“逐期”表（如果需要）；不再做“按年聚合”
+            IReadOnlyList<PiecewiseScheduleRow>? finalSchedule = generateSchedule ? periodRows : null;
+
+            return new PiecewiseResult(
                 InitialLoanAmount: input.InitialLoanAmount,
                 TotalPrincipal: Math.Round(totalPrincipal, 2),
                 TotalInterest: Math.Round(totalInterest, 2),
                 TotalCost: totalCost,
-                TotalPeriods: globalPeriod,
-                Schedule: schedule,
-                FirstSegmentPayment: firstSegmentPayment
+                TotalPeriods: globalPeriod,              // = sum(seg.TermPeriods)
+                Schedule: finalSchedule,                 // 逐期 or null
+                FirstSegmentPayment: Math.Round(firstSegmentPayment, 2)
             );
-            return result;
         }
     }
 }

--- a/backend/SettlyFinanceTests/PiecewiseAmortizerTests.cs
+++ b/backend/SettlyFinanceTests/PiecewiseAmortizerTests.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using SettlyFinance.Calculators.Orchestrators;
 using SettlyFinance.Enums;
 using SettlyFinance.Interfaces;
@@ -14,7 +12,7 @@ namespace SettlyFinanceTests
     public class PiecewiseAmortizerTests
     {
         private IPiecewiseAmortizer CreateAmortizer(int ppy = 12)
-                   => new PiecewiseAmortizer(new TestEngineFactory(new FakeFrequencyProvider(ppy)));
+            => new PiecewiseAmortizer(new TestEngineFactory(new FakeFrequencyProvider(ppy)));
 
         [Fact]
         public void IO_Then_PnI_AggregatesCorrectly()
@@ -25,44 +23,67 @@ namespace SettlyFinanceTests
                 InitialLoanAmount: 600000m,
                 Segments: new[]
                 {
-            new PiecewiseSegmentInput(
-                RepaymentType: RepaymentType.InterestOnly,
-                AnnualInterestRate: 0.059m,
-                TermPeriods: 24,
-                Frequency: RepaymentFrequency.Monthly,
-                GenerateSchedule: true,
-                Label: "IO 24m @5.9%"
-            ),
-            new PiecewiseSegmentInput(
-                RepaymentType: RepaymentType.PrincipalAndInterest,
-                AnnualInterestRate: 0.065m,
-                TermPeriods: 336,
-                Frequency: RepaymentFrequency.Monthly,
-                GenerateSchedule: true,
-                Label: "PnI 28y @6.5%"
-            )
+                    new PiecewiseSegmentInput(
+                        RepaymentType: RepaymentType.InterestOnly,
+                        AnnualInterestRate: 0.059m,
+                        TermPeriods: 24,
+                        Frequency: RepaymentFrequency.Monthly,
+                        GenerateSchedule: true,
+                        Label: "IO 24m @5.9%"
+                    ),
+                    new PiecewiseSegmentInput(
+                        RepaymentType: RepaymentType.PrincipalAndInterest,
+                        AnnualInterestRate: 0.065m,
+                        TermPeriods: 336,
+                        Frequency: RepaymentFrequency.Monthly,
+                        GenerateSchedule: true,
+                        Label: "PnI 28y @6.5%"
+                    )
                 },
                 GenerateSchedule: true
             );
 
             var r = amortizer.Calculate(input);
 
+            // 逐期：360 行
             Assert.Equal(360, r.TotalPeriods);
             Assert.NotNull(r.Schedule);
             Assert.Equal(360, r.Schedule!.Count);
+
             var fp = new FakeFrequencyProvider(12);
+
+            // 期望：IO 段（24期，逐期） + PNI 段（按剩余336期算期供）
             var ioExpected = new SettlyFinance.Calculators.Engines.IoEngine(fp).Calculate(
-                new SettlyFinanceTests.Helpers.IoInputBuilder()
+                new IoInputBuilder()
                     .Loan(600000m).Rate(0.059m).Periods(24).Freq(RepaymentFrequency.Monthly).WithSchedule(true)
                     .Build()
             );
             var pniExpected = new SettlyFinance.Calculators.Engines.PniEngine(fp).Calculate(
-                new SettlyFinanceTests.Helpers.PniInputBuilder()
+                new PniInputBuilder()
                     .Loan(600000m).Rate(0.065m).Periods(336).Freq(RepaymentFrequency.Monthly).WithSchedule(true)
                     .Build()
             );
-            ApproxAssert.Equal(ioExpected.Payment, r.Schedule![0].Payment, 0.01m);
-            ApproxAssert.Equal(pniExpected.Payment, r.Schedule![24].Payment, 0.02m);
+
+            // 首段是 IO：FirstSegmentPayment = IO 每期利息
+            ApproxAssert.Equal(ioExpected.Payment, r.FirstSegmentPayment, 0.01m);
+
+            // 第1期为 IO
+            var m1 = r.Schedule![0];
+            ApproxAssert.Equal(ioExpected.Payment, m1.Payment, 0.01m);
+            ApproxAssert.Equal(ioExpected.Schedule![0].Interest, m1.Interest, 0.01m);
+            ApproxAssert.Equal(0m, m1.Principal, 0.01m);
+
+            // 第24期（IO 段末）
+            var m24 = r.Schedule![23];
+            ApproxAssert.Equal(ioExpected.Schedule![23].Payment, m24.Payment, 0.01m);
+            ApproxAssert.Equal(ioExpected.Schedule![23].Interest, m24.Interest, 0.01m);
+            ApproxAssert.Equal(ioExpected.Schedule![23].EndingBalance, m24.EndingBalance, 0.01m);
+
+            // 第25期进入 PNI：期供应与“剩余336期”的 PNI 引擎一致
+            var m25 = r.Schedule![24];
+            ApproxAssert.Equal(pniExpected.Payment, m25.Payment, 0.02m);
+
+            // 总利息 = IO 段利息 + PNI 段利息（到分）
             var expectedSum = ioExpected.TotalInterest + pniExpected.TotalInterest;
             var expectedRounded = Math.Round(expectedSum, 2);
             Assert.Equal(expectedRounded, r.TotalInterest);
@@ -72,33 +93,52 @@ namespace SettlyFinanceTests
         public void SingleSegment_Equals_PniEngine_Result()
         {
             var amortizer = CreateAmortizer();
+
             var input = new PiecewiseInput(
                 InitialLoanAmount: 600000m,
                 Segments: new[]
                 {
-            new PiecewiseSegmentInput(
-                RepaymentType: RepaymentType.PrincipalAndInterest,
-                AnnualInterestRate: 0.065m,
-                TermPeriods: 360,
-                Frequency: RepaymentFrequency.Monthly,
-                GenerateSchedule: true,
-                Label: null
-            )
+                    new PiecewiseSegmentInput(
+                        RepaymentType: RepaymentType.PrincipalAndInterest,
+                        AnnualInterestRate: 0.065m,
+                        TermPeriods: 360,
+                        Frequency: RepaymentFrequency.Monthly,
+                        GenerateSchedule: true,
+                        Label: null
+                    )
                 },
                 GenerateSchedule: true
             );
+
             var r = amortizer.Calculate(input);
+
+            // 逐期：360 行
+            Assert.Equal(360, r.TotalPeriods);
+            Assert.NotNull(r.Schedule);
+            Assert.Equal(360, r.Schedule!.Count);
+
             var pni = new SettlyFinance.Calculators.Engines.PniEngine(new FakeFrequencyProvider(12));
             var pniResult = pni.Calculate(
-                new SettlyFinanceTests.Helpers.PniInputBuilder()
+                new PniInputBuilder()
                     .Loan(600000m).Rate(0.065m).Periods(360).Freq(RepaymentFrequency.Monthly).WithSchedule(true)
                     .Build()
             );
-            ApproxAssert.Equal(pniResult.Payment, r.Schedule![0].Payment, 0.01m);
+
+            // 首段就是 PNI：FirstSegmentPayment 等于 PNI 期供
+            ApproxAssert.Equal(pniResult.Payment, r.FirstSegmentPayment, 0.01m);
+
+            // 第1期逐期对得上
+            var m1 = r.Schedule![0];
+            ApproxAssert.Equal(pniResult.Schedule![0].Payment, m1.Payment, 0.02m);
+            ApproxAssert.Equal(pniResult.Schedule![0].Interest, m1.Interest, 0.02m);
+            ApproxAssert.Equal(pniResult.Schedule![0].Principal, m1.Principal, 0.02m);
+            ApproxAssert.Equal(pniResult.Schedule![0].EndingBalance, m1.EndingBalance, 0.02m);
+
+            // 总利息一致（到分）
             var expectedRounded = Math.Round(pniResult.TotalInterest, 2);
             Assert.Equal(expectedRounded, r.TotalInterest);
-            Assert.Equal(pniResult.TermPeriods, r.TotalPeriods);
         }
+
         [Fact]
         public void Throws_On_InvalidInputs()
         {
@@ -120,14 +160,16 @@ namespace SettlyFinanceTests
                     GenerateSchedule: false
                 ))
             );
+
             Assert.Throws<System.ArgumentException>(() =>
                 amortizer.Calculate(new PiecewiseInput(
                     InitialLoanAmount: 1_000m,
-                    Segments: new PiecewiseSegmentInput[] { }, 
+                    Segments: new PiecewiseSegmentInput[] { },
                     GenerateSchedule: false
                 ))
             );
         }
+
         [Fact]
         public void When_NoSchedule_TotalPeriods_StillAggregates()
         {
@@ -156,6 +198,7 @@ namespace SettlyFinanceTests
                 },
                 GenerateSchedule: false
             ));
+
             Assert.Null(r.Schedule);
             Assert.Equal(132, r.TotalPeriods);
         }

--- a/backend/SettlyModels/Dtos/Loan/AmortizationRequestDto.cs
+++ b/backend/SettlyModels/Dtos/Loan/AmortizationRequestDto.cs
@@ -15,6 +15,7 @@ namespace SettlyModels.DTOs.Loan
         [property: JsonConverter(typeof(JsonStringEnumConverter))]
         RepaymentType RepaymentType,
         bool GenerateSchedule = false,
-        decimal? NetAnnualIncome = null
+        decimal? NetAnnualIncome = null,
+        bool? AggregateScheduleByYear = null //optional for Yearly Schedule
     );
 } 

--- a/backend/SettlyModels/Dtos/Loan/PiecewiseRequestDto.cs
+++ b/backend/SettlyModels/Dtos/Loan/PiecewiseRequestDto.cs
@@ -17,6 +17,7 @@ namespace SettlyModels.DTOs.Loan
         RepaymentFrequency Frequency,
         List<PiecewiseSegmentDto> Segments,
         bool GenerateSchedule = true,
-        decimal? NetAnnualIncome = null
+        decimal? NetAnnualIncome = null,
+        bool? AggregateScheduleByYear = null//optional for Yearly Schedule
     );
 }

--- a/backend/SettlyService/LoanCalculatorService.cs
+++ b/backend/SettlyService/LoanCalculatorService.cs
@@ -7,6 +7,7 @@ using SettlyFinance.Interfaces;
 using SettlyFinance.Models;
 using SettlyModels.DTOs;
 using SettlyModels.DTOs.Loan;
+
 namespace SettlyService
 {
     /// <summary>
@@ -22,20 +23,26 @@ namespace SettlyService
         {
             _facade = facade ?? throw new ArgumentNullException(nameof(facade));
         }
+
         public LoanWrapperDtoResponse Calculate(LoanWrapperDtoRequest dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
+
             var hasAm = dto.Amortization is not null;
             var hasPw = dto.Piecewise is not null;
             if (hasAm == hasPw)
                 throw new ArgumentException("Request must contain exactly one of 'Amortization' or 'Piecewise'.", nameof(dto));
+
             AmortizationResponseDto? amortizationResponse = null;
             PiecewiseResponseDto? piecewiseResponse = null;
+
+            // -------------------- PIECEWISE --------------------
             if (hasPw)
             {
                 var pwReq = dto.Piecewise!;
                 if (pwReq.Segments is null || pwReq.Segments.Count == 0)
                     throw new ArgumentException("Piecewise.Segments must contain at least one segment.");
+
                 int ppy = GetPeriodsPerYear(pwReq.Frequency);
 
                 var segments = pwReq.Segments.Select((s, idx) =>
@@ -44,26 +51,50 @@ namespace SettlyService
                         throw new ArgumentException($"Segments[{idx}].LoanTermYears must be > 0.");
                     int termPeriods = checked(s.LoanTermYears * ppy);
                     var normalizedRate = NormalizeAnnualRate(s.AnnualInterestRate);
+
                     return new PiecewiseSegmentInput(
                         RepaymentType: s.RepaymentType,
                         AnnualInterestRate: normalizedRate,
                         TermPeriods: termPeriods,
-                        Frequency: pwReq.Frequency, 
-                        GenerateSchedule: true,    
+                        Frequency: pwReq.Frequency,                // 统一频率
+                        GenerateSchedule: true,                    // 领域层先生成逐期，必要时再在 Service 聚合
                         Label: MakeSegmentLabel(s.RepaymentType, s.LoanTermYears, normalizedRate, pwReq.Frequency)
                     );
                 }).ToList();
+
                 var domainInput = new PiecewiseInput(
                     InitialLoanAmount: pwReq.InitialLoanAmount,
                     Segments: segments,
                     GenerateSchedule: pwReq.GenerateSchedule
                 );
+
                 var result = _facade.CalculateLoan(domainInput);
+
+                // 收支比：用请求频率换算每期收入，与 FirstSegmentPayment 的单位一致
                 string? ratioPercent = ComputePaymentToIncomeRatioPercent(
                     paymentPerPeriod: result.FirstSegmentPayment,
                     netAnnualIncome: pwReq.NetAnnualIncome,
                     frequency: pwReq.Frequency
                 );
+
+                // 逐期 -> DTO
+                var scheduleDto = result.Schedule?.Select(r => new PiecewiseScheduleRowDto(
+                    GlobalPeriod: r.GlobalPeriod,
+                    SegmentIndex: r.SegmentIndex,
+                    SegmentPeriod: r.SegmentPeriod,
+                    Payment: r.Payment,
+                    Interest: r.Interest,
+                    Principal: r.Principal,
+                    EndingBalance: r.EndingBalance,
+                    SegmentLabel: r.SegmentLabel
+                )).ToList();
+
+                // ★ 可选：仅当请求显式要求按年聚合时，才把逐期聚合为年度（不影响默认前端）
+                if (pwReq.AggregateScheduleByYear == true && scheduleDto is not null && scheduleDto.Count > 0)
+                {
+                    scheduleDto = AggregateYearlyDto(scheduleDto, ppy).ToList();
+                }
+
                 piecewiseResponse = new PiecewiseResponseDto(
                     InitialLoanAmount: result.InitialLoanAmount,
                     TotalPrincipal: result.TotalPrincipal,
@@ -71,41 +102,37 @@ namespace SettlyService
                     TotalCost: result.TotalCost,
                     TotalPeriods: result.TotalPeriods,
                     FirstSegmentPayment: result.FirstSegmentPayment,
-                    Schedule: result.Schedule?.Select(r => new PiecewiseScheduleRowDto(
-                        GlobalPeriod: r.GlobalPeriod,
-                        SegmentIndex: r.SegmentIndex,
-                        SegmentPeriod: r.SegmentPeriod,
-                        Payment: r.Payment,
-                        Interest: r.Interest,
-                        Principal: r.Principal,
-                        EndingBalance: r.EndingBalance,
-                        SegmentLabel: r.SegmentLabel
-                    )).ToList(),
+                    Schedule: scheduleDto,
                     FirstSegmentPaymentToIncomeRatioPercent: ratioPercent
                 );
             }
+            // -------------------- SINGLE (Amortization) --------------------
             else
             {
                 var amReq = dto.Amortization!;
                 if (amReq.LoanTermYears <= 0)
                     throw new ArgumentException("Amortization.loanTermYears must be > 0.");
+
                 int resolvedTerm = checked(amReq.LoanTermYears * GetPeriodsPerYear(amReq.Frequency));
+
                 var singleSegment = new PiecewiseSegmentInput(
                     RepaymentType: amReq.RepaymentType,
                     AnnualInterestRate: NormalizeAnnualRate(amReq.AnnualInterestRate),
                     TermPeriods: resolvedTerm,
                     Frequency: amReq.Frequency,
-                    GenerateSchedule: true, 
+                    GenerateSchedule: true, // 领域层先逐期
                     Label: MakeSegmentLabel(amReq.RepaymentType, amReq.LoanTermYears, NormalizeAnnualRate(amReq.AnnualInterestRate), amReq.Frequency)
                 );
+
                 var pwForSingle = new PiecewiseInput(
                     InitialLoanAmount: amReq.LoanAmount,
                     Segments: new List<PiecewiseSegmentInput> { singleSegment },
                     GenerateSchedule: amReq.GenerateSchedule
                 );
+
                 var pwResult = _facade.CalculateLoan(pwForSingle);
                 var firstPayment = pwResult.FirstSegmentPayment;
-                // var displayPayment = (int)Math.Ceiling(firstPayment);
+
                 var scheduleRows = pwResult.Schedule?.Select(row => new AmortizationScheduleRowDto(
                     Period: row.GlobalPeriod,
                     Payment: row.Payment,
@@ -113,18 +140,26 @@ namespace SettlyService
                     Principal: row.Principal,
                     EndingBalance: row.EndingBalance
                 )).ToList();
+
+                // ★ 可选：单段也支持按年聚合
+                if (amReq.AggregateScheduleByYear == true && scheduleRows is not null && scheduleRows.Count > 0)
+                {
+                    int ppy = GetPeriodsPerYear(amReq.Frequency);
+                    scheduleRows = AggregateYearlyDto(scheduleRows, ppy).ToList();
+                }
+
                 string? ratioPercent = ComputePaymentToIncomeRatioPercent(
                     paymentPerPeriod: firstPayment,
                     netAnnualIncome: amReq.NetAnnualIncome,
                     frequency: amReq.Frequency
                 );
+
                 amortizationResponse = new AmortizationResponseDto(
                     LoanAmount: amReq.LoanAmount,
                     AnnualInterestRate: amReq.AnnualInterestRate,
                     Frequency: amReq.Frequency,
                     RepaymentType: amReq.RepaymentType,
                     Payment: firstPayment,
-                    //DisplayPayment: displayPayment,
                     TotalInterest: pwResult.TotalInterest,
                     TotalPrincipal: pwResult.TotalPrincipal,
                     TotalCost: pwResult.TotalCost,
@@ -133,20 +168,26 @@ namespace SettlyService
                     PaymentToIncomeRatioPercent: ratioPercent
                 );
             }
+
             return new LoanWrapperDtoResponse(amortizationResponse, piecewiseResponse);
         }
+
+        // -------------------- Helpers --------------------
+
         private static decimal NormalizeAnnualRate(decimal r)
         {
             if (r < 0) throw new ArgumentOutOfRangeException(nameof(r), "Annual interest rate cannot be negative");
             if (r <= 1m) return r;
             if (r <= 100m) return r / 100m;
-            throw new ArgumentOutOfRangeException(nameof(r),"Annual interest rate looks too large. Use decimal (e.g., 0.065) or percent (e.g., 6.5).");
+            throw new ArgumentOutOfRangeException(nameof(r), "Annual interest rate looks too large. Use decimal (e.g., 0.065) or percent (e.g., 6.5).");
         }
+
         private static string MakeSegmentLabel(RepaymentType type, int years, decimal annualRate, RepaymentFrequency freq)
         {
             var kind = type == RepaymentType.InterestOnly ? "IO" : "P&I";
             return $"{kind} {years}y @ {(annualRate * 100m):0.###}% ({freq})";
         }
+
         private static int GetPeriodsPerYear(RepaymentFrequency frequency) => frequency switch
         {
             RepaymentFrequency.Monthly => 12,
@@ -154,14 +195,52 @@ namespace SettlyService
             RepaymentFrequency.Weekly => 52,
             _ => throw new NotSupportedException($"Unsupported frequency: {frequency}")
         };
+
         private static string? ComputePaymentToIncomeRatioPercent(decimal paymentPerPeriod, decimal? netAnnualIncome, RepaymentFrequency frequency)
         {
             if (netAnnualIncome is null || netAnnualIncome <= 0m) return null;
             var ppy = GetPeriodsPerYear(frequency);
             var incomePerPeriod = netAnnualIncome.Value / ppy;
             if (incomePerPeriod <= 0m) return null;
-            var ratio = paymentPerPeriod / incomePerPeriod; 
-            return $"{(ratio * 100m):0.00}%"; 
+            var ratio = paymentPerPeriod / incomePerPeriod;
+            return $"{(ratio * 100m):0.00}%";
+        }
+
+        // ---- 年度聚合（单段 DTO）----
+        private static IEnumerable<AmortizationScheduleRowDto> AggregateYearlyDto(
+            List<AmortizationScheduleRowDto> rows, int periodsPerYear)
+        {
+            for (int start = 0, yearIdx = 1; start < rows.Count; start += periodsPerYear, yearIdx++)
+            {
+                var span = rows.Skip(start).Take(periodsPerYear).ToList();
+                yield return new AmortizationScheduleRowDto(
+                    Period: span.Last().Period, // 该年的最后一期
+                    Payment: span.Sum(r => r.Payment),
+                    Interest: span.Sum(r => r.Interest),
+                    Principal: span.Sum(r => r.Principal),
+                    EndingBalance: span.Last().EndingBalance
+                );
+            }
+        }
+
+        // ---- 年度聚合（分段 DTO）----
+        private static IEnumerable<PiecewiseScheduleRowDto> AggregateYearlyDto(
+            List<PiecewiseScheduleRowDto> rows, int periodsPerYear)
+        {
+            for (int start = 0, yearIdx = 1; start < rows.Count; start += periodsPerYear, yearIdx++)
+            {
+                var span = rows.Skip(start).Take(periodsPerYear).ToList();
+                yield return new PiecewiseScheduleRowDto(
+                    GlobalPeriod: span.Last().GlobalPeriod, // 该年的最后一期
+                    SegmentIndex: -1,                        // 年度汇总标识
+                    SegmentPeriod: yearIdx,                  // 年序号
+                    Payment: span.Sum(r => r.Payment),
+                    Interest: span.Sum(r => r.Interest),
+                    Principal: span.Sum(r => r.Principal),
+                    EndingBalance: span.Last().EndingBalance,
+                    SegmentLabel: $"Year {yearIdx} total"
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Description:

This PR fixed backend of loan calculator to calculate repayment issues; the issue was unable to correctly calculate the piecewise's total interest and total cost when starting with pni segment; This PR also added a 'switch' to generate schedule by year for AI; When requesting yearly schedule, add   "aggregateScheduleByYear": true in request body as below:

Example/request body: single with yearly schedule

{
  "loanAmount": 550000,
  "annualInterestRate": 6.2,
  "loanTermYears": 30,
  "frequency": "Monthly",
  "repaymentType": "PrincipalAndInterest",
  "aggregateScheduleByYear": true,
  "netAnnualIncome": 180000
}
------------------------------------------------

Example/request body: piecewise with yearly schedule

{
  "initialLoanAmount": 600000,
  "frequency": "Monthly",
  "aggregateScheduleByYear": true,
  "netAnnualIncome": 180000,
  "segments": [
    { "repaymentType": "InterestOnly", "annualInterestRate": 5.9, "loanTermYears": 2 },
    { "repaymentType": "PrincipalAndInterest", "annualInterestRate": 5.9, "loanTermYears": 28 }
  ]
}
<img width="994" height="463" alt="image" src="https://github.com/user-attachments/assets/7016d715-37d4-49de-9f14-9046c384e438" />

----------------------------
Previous generateSchedule has been kept for frontend which can be null. If more detailed schedule requested, please add   "generateSchedule": true when requesting


note:
// segmentIndex = -1 表示汇总行（例如每年合计，用于展示或导出报表）
// Not part of actual loan segments, only for UI summary rows like "Year 1 total"
